### PR TITLE
Default/Initial Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The `<Otter.Editor />` element renders the editor.
 | `save`               | `function(data)`                                |          |                  | Save the document.                                                                                                                 |
 | `update_height`      | `function(new_height_in_pixels)`                |          |                  | Called by Otter when the editor height changes, in case this is useful to you.                                                     |
 | `open_media_library` | `function(set_value)`                           |          |                  | Called by Otter when a `MediaPicker` button is clicked. Call `set_value` to set the picked item.                                   |
-| `dev_mode`           | `bool`                                          |          | `false`          | When true, clicking on a block copies its data to your clipboard. Useful when you want to scaffold out a blocks `initial_data`.   |
+| `dev_mode`           | `bool`                                          |          | `false`          | Add a button to copy a block's data to your clipboard. This lets you easily obtain a block's `initial_data`.                       |
 
 
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The `<Otter.Editor />` element renders the editor.
 | `save`               | `function(data)`                                |          |                  | Save the document.                                                                                                                 |
 | `update_height`      | `function(new_height_in_pixels)`                |          |                  | Called by Otter when the editor height changes, in case this is useful to you.                                                     |
 | `open_media_library` | `function(set_value)`                           |          |                  | Called by Otter when a `MediaPicker` button is clicked. Call `set_value` to set the picked item.                                   |
+| `dev_mode`           | `bool`                                          |          | `false`          | When true, clicking on a block copies its data to your clipboard. Useful when you want to scaffold out a blocks `initial_data`.   |
 
 
 
@@ -100,6 +101,7 @@ An example Block of type `PageHeader` might contain the Fields: `title`, `subtit
 | `type`        | `<string>`         | Yes      |         | The block type identifier. Each block's `type` string must be unique within the editor.                                                                         |
 | `description` | `<string>`         |          |         | A human-readable name for the block, identifying it clearly to the user. If not present Otter will use a prettified version of the block type.                  |
 | `fields`      | `Array(<Field>)`   | Yes      |         | The [fields](#fields) in this block.                                                                                                                            |
+| `initial_data`| `<object>`         |          |         | Optionally, provide initial data for the block.                                                                                                                 |
 | `thumbnail`   | `<path>`           |          |         | Optional thumbnail for use in the [graphical block picker](#blocks-optionally-categorise-in-groups).                                                            |
 | `hidden`      | `<bool>`           |          | `false` | If `true`, don't display this block in the block picker. This allows you to define blocks at the top level which can only be used in a NestedBlock or Repeater. |
 | `tabs`        | `Array(<Tab>)`     |          |         | Allows you to arrange the block's fields into tabs. See [block tabs](#block-tabs).
@@ -216,7 +218,8 @@ Properties on all field types:
 | `description`      | `<string>`                              |            | Field label displayed to the user. If not present Otter will use a prettified version of the field name. |
 | `type`             | `Otter.Field.<FieldType>`               | Yes        | The [field type](#field-types).                                                                          |
 | `display_if`       | `<DisplayRule>`, `Array(<DisplayRule>)` |            | Show/hide this field based on the value(s) of its sibling(s).                                            |
-| `default_value`*   | Any type, as appropriate                |            | A default value, used to set the field initially and to provide data on save if the field is empty       |
+| `default_value`*   | Any type, as appropriate                |            | A default value, used to set the field initially and to provide data on save if the field is empty.      |
+| `placeholder`      | `<string>`                              |            | For text and textarea inputs.                                                                            |
 | `wrapper_class`**  | `<string>`                              |            | Add custom classes to the field wrapper. See [custom layout](#custom-layout)                             |
 | `label_class`**    | `<string>`                              |            | Add custom classes to the field label. See [custom layout](#custom-layout)                               |
 | `field_class`**    | `<string>`                              |            | Add custom classes to the input or other field element. See [custom layout](#custom-layout)              |

--- a/src/core/components/fields/Select.jsx
+++ b/src/core/components/fields/Select.jsx
@@ -3,7 +3,7 @@ import OSelect from '../default-ui/OSelect'
 import {usePageData} from '../../contexts/PageDataContext'
 import {evaluate} from '../../definitions/utils'
 
-export default function Select({field_def, containing_data_item, ...props}) {
+export default function Select({field_def, containing_data_item, is_display_if_target, ...props}) {
   const ctx           = usePageData()
   const uid           = `${containing_data_item.__uid}-${field_def.name}`
   const value         = containing_data_item[field_def.name]

--- a/src/core/components/fields/TextArea.jsx
+++ b/src/core/components/fields/TextArea.jsx
@@ -14,6 +14,7 @@ export default function TextArea({
   const mono          = field_def.mono || false
   const default_value = evaluate(field_def.default_value)
   const display_value = (value === undefined ? default_value : value) || ''
+  const placeholder   = field_def.placeholder
 
   function cb__change(ev) {
     containing_data_item[field_def.name] = ev.target.value
@@ -25,6 +26,7 @@ export default function TextArea({
   return (
     <OTextarea value={display_value}
                onChange={cb__change}
+               placeholder={placeholder}
                monospaced={mono} />
   )
 }

--- a/src/core/components/fields/TextInput.jsx
+++ b/src/core/components/fields/TextInput.jsx
@@ -13,6 +13,7 @@ export default function TextInput({
   const value         = containing_data_item[field_def.name]
   const default_value = evaluate(field_def.default_value)
   const display_value = (value === undefined ? default_value : value) || ''
+  const placeholder   = field_def.placeholder
   const ref           = useRef()
 
   function cb__change(ev) {
@@ -25,6 +26,7 @@ export default function TextInput({
   return (
     <OInput value={display_value}
             onChange={cb__change}
+            placeholder={placeholder}
             ref={ref} />
   )
 }

--- a/src/core/components/otter/Block/Block.jsx
+++ b/src/core/components/otter/Block/Block.jsx
@@ -10,8 +10,18 @@ import {TabsProvider, TabsTab} from '../../primitives/Tabs'
 import {usePageData} from '../../../contexts/PageDataContext'
 import {find_block, humanify_str} from '../../../definitions/utils'
 import {classNames} from '../../../helpers/style'
+import deep_clean_obj from '../../../helpers/deep-clean-obj'
 import {useThemeContext} from '../../../contexts/ThemeContext'
 import TabBtns from '../other/TabBtns'
+
+
+function dev_mode_copy_block_data_to_clipboard(raw_block_data) {
+  navigator.clipboard
+    .writeText(JSON.stringify(deep_clean_obj(raw_block_data, ['__uid']), null, 4))
+    .then(() =>
+      console.log('dev_mode: copied block data to clipboard...'),
+    )
+}
 
 const drag_styles = { }
 
@@ -82,7 +92,10 @@ export default function Block({data_item, index, block_numbers}) {
                 <div className={classNames('relative', !open && 'overflow-hidden')}>
 
                   {block && (
-                    <div className="relative">
+                    <div className="relative"
+                         onClick={ctx.dev_mode ?
+                           () => dev_mode_copy_block_data_to_clipboard(ctx.data[index]) : null}
+                    >
                       <BlockAndRepeaterHeader heading={block.description || humanify_str(block.type)}
                                               block_number={block_numbers && index + 1}
                                               show_confirm_deletion={show_confirm_deletion}

--- a/src/core/components/otter/Block/Block.jsx
+++ b/src/core/components/otter/Block/Block.jsx
@@ -10,18 +10,8 @@ import {TabsProvider, TabsTab} from '../../primitives/Tabs'
 import {usePageData} from '../../../contexts/PageDataContext'
 import {find_block, humanify_str} from '../../../definitions/utils'
 import {classNames} from '../../../helpers/style'
-import deep_clean_obj from '../../../helpers/deep-clean-obj'
 import {useThemeContext} from '../../../contexts/ThemeContext'
 import TabBtns from '../other/TabBtns'
-
-
-function dev_mode_copy_block_data_to_clipboard(raw_block_data) {
-  navigator.clipboard
-    .writeText(JSON.stringify(deep_clean_obj(raw_block_data, ['__uid']), null, 4))
-    .then(() =>
-      console.log('dev_mode: copied block data to clipboard...'),
-    )
-}
 
 const drag_styles = { }
 
@@ -79,7 +69,6 @@ export default function Block({data_item, index, block_numbers}) {
                      minWidth: theme_ctx.design_options.block_min_width,
                    }}
               >
-
                 <BlockDeleteConfirmPopoverAnimated delete_func={() => ctx.delete_item(index)}
                                                    isOpen={show_confirm_deletion}
                                                    close={() => set_show_confirm_deletion(false)}
@@ -92,12 +81,10 @@ export default function Block({data_item, index, block_numbers}) {
                 <div className={classNames('relative', !open && 'overflow-hidden')}>
 
                   {block && (
-                    <div className="relative"
-                         onClick={ctx.dev_mode ?
-                           () => dev_mode_copy_block_data_to_clipboard(ctx.data[index]) : null}
-                    >
+                    <div className="relative">
                       <BlockAndRepeaterHeader heading={block.description || humanify_str(block.type)}
-                                              block_number={block_numbers && index + 1}
+                                              index={index}
+                                              block_numbers={block_numbers}
                                               show_confirm_deletion={show_confirm_deletion}
                                               delete_func={ctx.can_add_blocks ? () => set_show_confirm_deletion(true) : null}
                                               open={open}

--- a/src/core/components/otter/Block/BlockSection.jsx
+++ b/src/core/components/otter/Block/BlockSection.jsx
@@ -54,9 +54,9 @@ export default function BlockSection({
       {heading && (
         <BlockSectionHeading heading={heading}
                              heading_align={heading_align}
-                             onClick={() => set_open(!open)}
                              open={open}
                              enabled={enabled}
+                             toggle_open={() => set_open(!open)}
                              toggle_enabled={toggle_enabled}
                              set_open={set_open}
                              optional={optional} />

--- a/src/core/components/otter/Block/BlockSectionHeading.jsx
+++ b/src/core/components/otter/Block/BlockSectionHeading.jsx
@@ -11,9 +11,9 @@ export default function BlockSectionHeading({
   className = classes.skin.block.bg,
   open,
   set_open,
-  onClick,
   optional,
   enabled,
+  toggle_open,
   toggle_enabled,
   ...props
 }) {
@@ -31,7 +31,7 @@ export default function BlockSectionHeading({
       theme_ctx.classes.typography.heading,
       className,
     )}
-         onClick={!optional ? onClick : null}
+         onClick={!optional ? toggle_open : null}
          {...props}
     >
       <div className="flex items-center justify-between space-x-2 w-full">
@@ -42,7 +42,7 @@ export default function BlockSectionHeading({
             'space-x-1 cursor-pointer',
             !enabled && 'opacity-40 pointer-events-none',
           )}
-               onClick={optional ? onClick : null}
+               onClick={optional ? toggle_open : null}
           >
             <span>{heading}</span>
             {enabled && (

--- a/src/core/components/otter/Editor.jsx
+++ b/src/core/components/otter/Editor.jsx
@@ -158,7 +158,7 @@ export default function Editor({
   blocks = [],
   data = [],
   load_state,
-  block_numbers = false,
+  block_numbers,
   can_add_blocks = true,
   DragDropContext = DnD.DragDropContext,
   Droppable = DnD.Droppable,
@@ -170,7 +170,7 @@ export default function Editor({
   save,
   update_height,
   open_media_library,
-  dev_mode = false,
+  dev_mode,
 }) {
   const valid_state = Object.values(State).includes(load_state)
   const [block_picker, set_block_picker] = useState(false)

--- a/src/core/components/otter/NestedBlockWrapper.jsx
+++ b/src/core/components/otter/NestedBlockWrapper.jsx
@@ -6,12 +6,10 @@ import BlockSection from './Block/BlockSection'
 export default function NestedBlockWrapper({field_def, field_name, blocks, index, containing_data_item, children}) {
   const ctx                    = usePageData()
   const title                  = field_def.description || humanify_str(field_def.name)
-  const optional               = field_def.optional
-  const seamless               = field_def.seamless
-  const initially_open         = field_def.initially_open || false
-  const fallback_enabled_value = !optional ? true : field_def.__enabled_default_value
-  const [enabled, set_enabled] = useState(
-    containing_data_item[field_def.name]?.__enabled || fallback_enabled_value)
+  const seamless               = field_def.seamless === true
+  const optional               = field_def.optional === true && !seamless
+  const initially_open         = (field_def.initially_open || seamless) || false
+  const [enabled, set_enabled] = useState(!optional ? true : containing_data_item[field_name]?.__enabled)
 
   function cb__toggle_enabled() {
     if (field_def.optional) {
@@ -30,11 +28,11 @@ export default function NestedBlockWrapper({field_def, field_name, blocks, index
                   blocks={blocks}
                   children={children}
                   is_first={index === 0}
-                  enabled={enabled}
-                  optional={optional}
-                  seamless={seamless}
                   disable_bottom_pad={true}
                   containing_data_item={containing_data_item}
+                  optional={optional}
+                  seamless={seamless}
+                  enabled={enabled}
                   toggle_enabled={cb__toggle_enabled}
                   initially_open={initially_open} />
   )

--- a/src/core/components/otter/Repeater/RepeaterItem.jsx
+++ b/src/core/components/otter/Repeater/RepeaterItem.jsx
@@ -121,7 +121,8 @@ export default function RepeaterItem({
                                                      )}
                                                      transformOrigin="right" />
                   <BlockAndRepeaterHeader heading={title}
-                                          block_number={index + 1}
+                                          index={index}
+                                          block_numbers={true}
                                           show_confirm_deletion={show_confirm_deletion}
                                           delete_func={() => set_show_confirm_deletion(true)}
                                           open={open}

--- a/src/core/components/otter/other/BlockAndRepeaterHeader.jsx
+++ b/src/core/components/otter/other/BlockAndRepeaterHeader.jsx
@@ -1,9 +1,20 @@
 import React from 'react'
 import ChevronDownSolid from 'simple-react-heroicons/icons/ChevronDownSolid'
+import ClipboardCopySolid from 'simple-react-heroicons/icons/ClipboardCopySolid'
 import TrashSolid from 'simple-react-heroicons/icons/TrashSolid'
-import {classNames} from '../../../helpers/style'
 import {TabsBtn} from '../../primitives/Tabs'
 import {useThemeContext} from '../../../contexts/ThemeContext'
+import {usePageData} from '../../../contexts/PageDataContext'
+import {classNames} from '../../../helpers/style'
+import deep_clean_obj from '../../../helpers/deep-clean-obj'
+
+function copy_to_clipboard(raw_block_data) {
+  navigator.clipboard
+    .writeText(JSON.stringify(deep_clean_obj(raw_block_data, ['__uid']), null, 2))
+    .then(() =>
+      console.log('Copied block data to clipboard.'),
+    )
+}
 
 export const TabIcon = ({
   Icon,
@@ -15,25 +26,24 @@ export const TabIcon = ({
   is_last,
 }) => {
   return (
-    <div className={classNames(
-      'px-2',
-      'relative svg-font',
-      'flex items-center cursor-pointer',
-      iconThemeClassNamesObj.always,
-      active && !negativeAction && iconThemeClassNamesObj.active,
-      negativeAction && iconThemeClassNamesObj.negative,
-      !active && !negativeAction && iconThemeClassNamesObj.default,
-      is_last && '-mr-2',
-      className,
-    )}
-         onClick={onClick}
+    <div onClick={onClick}
+         className={classNames(
+           'px-2',
+           'relative svg-font',
+           'flex items-center cursor-pointer',
+           iconThemeClassNamesObj.always,
+           active && !negativeAction && iconThemeClassNamesObj.active,
+           negativeAction && iconThemeClassNamesObj.negative,
+           !active && !negativeAction && iconThemeClassNamesObj.default,
+           is_last && '-mr-2',
+           className,
+         )}
     >
-
       <span className={classNames(
         'absolute-center overflow-hidden w-full',
-        iconThemeClassNamesObj.active_indicator.border_radius,
-        iconThemeClassNamesObj.active_indicator.bg,
-        !active ? 'opacity-0' : iconThemeClassNamesObj.active_indicator.opacity,
+        iconThemeClassNamesObj.active_indicator?.border_radius,
+        iconThemeClassNamesObj.active_indicator?.bg,
+        !active ? 'opacity-0' : iconThemeClassNamesObj.active_indicator?.opacity,
       )}
       >
         <span className="aspect-1x1 w-full block"></span>
@@ -48,7 +58,8 @@ export const TabIcon = ({
 
 export default function BlockAndRepeaterHeader({
   heading,
-  block_number,
+  index,
+  block_numbers,
   tab_btn_icons,
   open,
   toggle_open,
@@ -61,6 +72,7 @@ export default function BlockAndRepeaterHeader({
   classNameYPad,
   iconThemeClassNamesObj,
 }) {
+  const ctx = usePageData()
   const theme_ctx = useThemeContext()
 
   return (
@@ -89,7 +101,7 @@ export default function BlockAndRepeaterHeader({
           classNameYPad,
         )}
         >
-          {block_number && <span className="w-4">{block_number}</span>}
+          {block_numbers && <span className="w-4">{index + 1}</span>}
           <span>{heading}</span>
         </h1>
 
@@ -105,16 +117,21 @@ export default function BlockAndRepeaterHeader({
       </div>
 
       <div className="flex svg-font items-center" style={{fontSize: '1.25em'}}>
+        {ctx.dev_mode && (
+          <TabIcon Icon={ClipboardCopySolid}
+                   onClick={() => copy_to_clipboard(ctx.data[index])}
+                   iconThemeClassNamesObj={iconThemeClassNamesObj} />
+        )}
 
         {tab_btn_icons && tab_btn_icons.map((Icon, i) => (
-          <TabsBtn  key={`tab-btn--${i}`}
-                    index={i}
-                    render={({active}) => (
-                      <TabIcon Icon={Icon}
-                               active={active}
-                               iconThemeClassNamesObj={iconThemeClassNamesObj}
-                               onClick={() => !open && toggle_open()} />
-                    )} />
+          <TabsBtn key={`tab-btn--${i}`}
+                   index={i}
+                   render={({active}) => (
+                     <TabIcon Icon={Icon}
+                              active={active}
+                              iconThemeClassNamesObj={iconThemeClassNamesObj}
+                              onClick={() => !open && toggle_open()} />
+                   )} />
         ))}
 
         {delete_func && (

--- a/src/core/helpers/deep-clean-obj.js
+++ b/src/core/helpers/deep-clean-obj.js
@@ -1,0 +1,15 @@
+export default function deep_clean_obj(obj, props_to_remove = []) {
+  return Object.entries(obj)
+    .reduce((carry, [prop, val]) => {
+      if (!props_to_remove.includes(prop)) {
+        if (Array.isArray(val)) {
+          val = val.map(item => deep_clean_obj(item, props_to_remove))
+        }
+        else if (typeof val === 'object' && val !== null) {
+          val = deep_clean_obj(val, props_to_remove)
+        }
+        carry[prop] = val
+      }
+      return carry
+    }, {})
+}


### PR DESCRIPTION
Resolves https://github.com/keepthatworktoyourself/otter/issues/13
Resolves https://github.com/keepthatworktoyourself/wombat/issues/38

- Adds ability to pass `initial_data` to a block
- Adds `placeholder` to field defs for text and textarea inputs
- Adds `dev_mode` prop to Editor - when dev_mode is true clicking anywhere on a block copies its data to your clipboard ready for use as `initial_data`
- `default_value` behavior change - empty string not considered null/empty for text and textarea fields. This allows a text fields default value to be overridden by emptying it out (this is how it works in ACF). Previous behavior was for an empty text field to revert to default_value after reload which was pretty confusing UX if the user intentionally had cleared a field. Any thoughts? 

Re default_value vs initial_value - I thought `default_value` was actually fine for the name in the end.

Passing `initial_data` in Wombat:
<img width="437" alt="Screenshot 2022-06-12 at 18 08 59" src="https://user-images.githubusercontent.com/11230219/173245208-745c7d7e-6f11-4e30-8577-848b8a378a32.png">

